### PR TITLE
Feature: Spam Prevention

### DIFF
--- a/.env_placeholder
+++ b/.env_placeholder
@@ -3,3 +3,5 @@ CHANNEL_ID=<channel_id_to_post_in>
 GUILD_ID=<guild_id>
 # Time between callouts in seconds default 30min (60 * 30 = 1800)
 TIMER=1800
+# Minimum amount of active VC users for bot to send message, default 1
+USER_THRESHOLD=1

--- a/.env_placeholder
+++ b/.env_placeholder
@@ -1,2 +1,5 @@
 DISCORD_TOKEN=<your_discord_token_here>
 CHANNEL_ID=<channel_id_to_post_in>
+GUILD_ID=<guild_id>
+# Time between callouts in seconds default 30min (60 * 30 = 1800)
+TIMER=1800

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use std::env;
 use dotenv::dotenv;
-use poise::serenity_prelude::{self as serenity, ChannelId, MessageBuilder};
+use poise::serenity_prelude::{self as serenity, futures::channel, ChannelId, ChannelType, Context as SerenityContext, GuildChannel, GuildId, Http as SerenityHttp, MessageBuilder};
 use std::sync::Arc;
 use timer::Timer;
 
@@ -20,14 +20,24 @@ async fn cooldown(
     Ok(())
 }
 
-pub async fn register_timer(http: Arc<poise::serenity_prelude::Http>) -> Timer {
+pub async fn register_timer(ctx: SerenityContext, http: Arc<SerenityHttp>) -> Timer {
     loop {
-        tokio::time::sleep(tokio::time::Duration::from_secs(60 * 30)).await; // Set timer to 30 minutes
-        posture_check_callout(&http).await;
+        tokio::time::sleep(tokio::time::Duration::from_secs(get_env_timer())).await; // Set timer from .env
+        posture_check_callout(&ctx, &http).await;
     }
 }
 
-pub fn get_posture_callout_channel() -> ChannelId  {
+// TODO: Move to lib/separate crate
+/* HELPERS */
+pub fn get_env_timer() -> u64 {
+    // TODO: Read initial setting from env, register changes via application command, e.g. "/set_channel #lobby"
+    // FIX: Proper Error Handling - If unparsable, safely shutdown
+    let timer = env::var("TIMER").expect("missing TIMER in .env").parse::<u64>().unwrap();
+
+    timer
+}
+
+pub fn get_env_posture_callout_channel() -> ChannelId {
     // TODO: Read initial setting from env, register changes via application command, e.g. "/set_channel #lobby"
     // FIX: Proper Error Handling - If unparsable, safely shutdown
     let channel_id = env::var("CHANNEL_ID").expect("missing CHANNEL_ID in .env").parse::<u64>().unwrap();
@@ -35,17 +45,54 @@ pub fn get_posture_callout_channel() -> ChannelId  {
     ChannelId::new(channel_id)
 }
 
-pub async fn posture_check_callout(http: &poise::serenity_prelude::Http) {
-    let channel_id = get_posture_callout_channel();
+pub fn get_env_guild_id() -> GuildId {
+    let guild_id = env::var("GUILD_ID").expect("missing GUILD_ID in .env").parse::<u64>().unwrap();
 
-    let response = MessageBuilder::new()
-        .push("@here") // TODO: Change this to get all users currently in voice channels
-        .push("\n\nPOSTURE CHECK RIGHT NOW")
-        .build();
+    GuildId::new(guild_id)
+}
 
-    if let Err(why) = channel_id.say(http, &response).await {
-        println!("Error sending message: {why:?}");
+pub fn get_voice_channels(ctx: &SerenityContext, guild_id: GuildId) -> Vec<GuildChannel> {
+    let mut voice_channels = Vec::<GuildChannel>::new();
+
+    if let Some(guild) = ctx.cache.guild(guild_id) {
+        for channel in guild.channels.values() {
+            if let ChannelType::Voice = channel.kind {
+                voice_channels.push(channel.clone());
+            }
+        }
     }
+
+    voice_channels
+}
+/* END OF HELPERS */
+
+pub async fn posture_check_callout(ctx: &SerenityContext, http: &SerenityHttp) {
+    let channel_id = get_env_posture_callout_channel();
+
+    if (is_voice_active(&ctx).await) {
+        let response = MessageBuilder::new()
+            //.push("@here") // TODO: Change this to get all users currently in voice channels
+            .push("\n\nPOSTURE CHECK RIGHT NOW")
+            .build();
+    
+        if let Err(why) = channel_id.say(http, &response).await {
+            println!("Error sending message: {why:?}");
+        }
+    }
+}
+
+pub async fn is_voice_active(ctx: &SerenityContext) -> bool {
+    let voice_channels = get_voice_channels(&ctx, get_env_guild_id());
+
+    for channel in voice_channels {
+        let active_members = channel.members(ctx).unwrap();
+        
+        if active_members.len() > 1 {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 #[tokio::main]
@@ -64,9 +111,10 @@ async fn main() {
         .setup(|ctx, _ready, framework| {
             println!("Running setup...");
             let http_clone = ctx.http.clone();
+            let ctx_clone = ctx.clone();
             // Get Posture Check Timer
             tokio::spawn(async move {
-                register_timer(http_clone).await;
+                register_timer(ctx_clone, http_clone).await;
             });
 
             println!("Posture Bot is up and running!");

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,12 @@ pub fn get_env_guild_id() -> GuildId {
     GuildId::new(guild_id)
 }
 
+pub fn get_env_user_threshold() -> usize {
+    let user_threshold = env::var("USER_THRESHOLD").expect("missing USER_THRESHOLD in .env").parse::<usize>().unwrap();
+
+    user_threshold
+}
+
 pub fn get_voice_channels(ctx: &SerenityContext, guild_id: GuildId) -> Vec<GuildChannel> {
     let mut voice_channels = Vec::<GuildChannel>::new();
 
@@ -87,7 +93,7 @@ pub async fn is_voice_active(ctx: &SerenityContext) -> bool {
     for channel in voice_channels {
         let active_members = channel.members(ctx).unwrap();
         
-        if active_members.len() > 1 {
+        if active_members.len() > get_env_user_threshold() {
             return true;
         }
     }


### PR DESCRIPTION
Added some features and configuration options to prevent spam.

* Adjustable Timer - The timer between callouts can now be configured in the .env (Default: 1800, value is in seconds)
* User Mentions - The bot no longer spams @here and instead fetches all users who are currently in a voice channel
* User Threshold - Added a config option in the .env for a minimum user threshold, below which, the bot does not send the message (Default: 1)